### PR TITLE
feat: Implement backend stream proxy for ESP32-CAM

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import importlib # 導入 importlib 模組，用於動態導入其他 Python 模
 import asyncio # 導入 asyncio 模組，用於非同步編程。
 import sys # 導入 sys 模組，提供對 Python 解釋器相關變數和函數的訪問。
 import subprocess # 導入 subprocess 模組，用於創建和管理子進程。
+import logging # 導入 logging 模組，用於日誌記錄。
 
 # 導入 CameraStreamProcessor 類，它負責處理來自 ESP32-CAM 的影像串流。
 from src.py_rear.services.camera_stream_processor import CameraStreamProcessor
@@ -104,4 +105,8 @@ if __name__ == "__main__":
     # 使用 uvicorn 運行 FastAPI 應用程式。
     # host="0.0.0.0" 表示伺服器將監聽所有可用的網路介面，允許從外部訪問。
     # port=8000 表示伺服器將在 8000 埠上運行。
+
+    # 配置日誌格式，包含時間戳
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/py_rear/apis/camera.py
+++ b/src/py_rear/apis/camera.py
@@ -3,6 +3,7 @@ from fastapi.responses import StreamingResponse # 導入 StreamingResponse，用
 import io # 導入 io 模組，用於處理位元組串流。
 import cv2 # 導入 OpenCV 函式庫，用於影像處理。
 import base64 # 導入 base64 模組，用於編碼和解碼資料。
+import asyncio # 導入 asyncio 模組，用於非同步操作。
 
 # camera_processor 變數將在 main.py 啟動時被設定為 CameraStreamProcessor 的實例。
 camera_processor = None
@@ -76,7 +77,7 @@ async def video_feed():
         raise HTTPException(status_code=404, detail="Camera stream not running.")
 
     async def generate_mjpeg_frames():
-        while True:
+        while camera_processor.is_running():
             frame_bytes, _, _ = camera_processor.get_latest_frame()
             if frame_bytes:
                 yield (b'--frame\r\n'

--- a/src/py_rear/apis/vehicle_api.py
+++ b/src/py_rear/apis/vehicle_api.py
@@ -151,16 +151,14 @@ async def register_camera(request_data: RegisterCameraRequest, request: Request)
     add_backend_log(f"已註冊 ESP32-S3 IP: {latest_esp32_cam_ip}") # 添加日誌訊息。
     add_backend_log(f"----------------------------------------") # 添加日誌訊息。
     
-    broadcast_process = request.app.state.broadcast_process
-    if broadcast_process:
+    if hasattr(request.app.state, 'broadcast_process') and request.app.state.broadcast_process:
         print("從 API 請求停止 IP 廣播腳本...")
-        broadcast_process.terminate()
+        request.app.state.broadcast_process.terminate()
         request.app.state.broadcast_process = None # 清除進程引用。
         print("廣播腳本已停止。")
 
     if apis_camera.camera_processor: # 如果 camera_processor 已經初始化。
         apis_camera.camera_processor.update_stream_source(latest_esp32_cam_ip) # 更新影像串流來源。
-        apis_camera.camera_processor.start() # 啟動影像串流處理器。
     else:
         add_backend_log("警告: apis_camera.camera_processor 未初始化。無法啟動串流。", level="WARNING") # 添加警告日誌。
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -239,18 +239,35 @@
                 streamButtonText: 'Start Stream' // Text for the stream button
             },
             methods: {
-                toggleStream() {
+                async toggleStream() {
                     this.addLog(`Toggle Stream button clicked. Current URL: '${this.streamUrl}'`, 'gui', 'debug');
                     if (this.streamUrl) {
                         // If stream is running, stop it
-                        this.streamUrl = '';
-                        this.streamButtonText = 'Start Stream';
-                        this.addLog('Stream stopped.', 'gui', 'info');
+                        try {
+                            this.addLog('Stopping camera stream via backend...', 'gui', 'info');
+                            await fetch('/camera/stop', { method: 'POST' });
+                            this.streamUrl = '';
+                            this.streamButtonText = 'Start Stream';
+                            this.addLog('Stream stopped successfully.', 'gui', 'info');
+                        } catch (error) {
+                            this.addLog(`Error stopping stream: ${error.message}`, 'gui', 'error');
+                        }
                     } else {
                         // If stream is stopped, start it
-                        this.streamUrl = `http://${this.esp32CamIp}/stream`;
-                        this.streamButtonText = 'Stop Stream';
-                        this.addLog(`Starting stream from ${this.streamUrl}`, 'gui', 'info');
+                        try {
+                            this.addLog('Starting camera stream via backend...', 'gui', 'info');
+                            const response = await fetch('/camera/start', { method: 'POST' });
+                            const data = await response.json();
+                            if (response.ok) {
+                                this.streamUrl = '/camera/stream'; // Point to the backend proxy
+                                this.streamButtonText = 'Stop Stream';
+                                this.addLog(`Stream started. Pointing to: ${this.streamUrl}`, 'gui', 'info');
+                            } else {
+                                throw new Error(data.detail || 'Failed to start stream');
+                            }
+                        } catch (error) {
+                            this.addLog(`Error starting stream: ${error.message}`, 'gui', 'error');
+                        }
                     }
                 },
                 addLog(message, source = 'gui', level = 'info') {


### PR DESCRIPTION
    1 feat: 實作後端影像串流代理 (ESP32-CAM)
    2
    3 此 Pull Request 引入了 ESP32-CAM 影像串流的後端代理功能，使 Python
      後端能夠在處理影像串流的同時，將其提供給前端 GUI 顯示。這解決了先前只有單一客戶端（後端或 GUI）能同時連線到
      ESP32-CAM 串流的問題。
    4
    5 主要變更包括：
    6 - **`templates/index.html`**: 修改前端，使其從後端的 `/camera/stream` 端點請求影像串流，而非直接從
      ESP32-CAM。`toggleStream` 函式現在非同步呼叫後端 API (`/camera/start` 和 `/camera/stop`) 來管理串流。
    7 - **`src/py_rear/apis/camera.py`**:
    8     - 導入 `asyncio` 模組，解決 `generate_mjpeg_frames` 中的 `NameError`。
    9     - 確保 `generate_mjpeg_frames` 在 `camera_processor` 未運行時能正確終止，避免
      `ERR_INCOMPLETE_CHUNKED_ENCODING` 錯誤。
   10 - **`src/py_rear/apis/vehicle_api.py`**:
   11     - 增加對 `request.app.state.broadcast_process` 的檢查，避免 `AttributeError`。
   12     - 移除相機註冊時自動啟動串流的邏輯，將啟動控制權交由前端的「啟動串流」按鈕。
   13 - **`src/py_rear/services/camera_stream_processor.py`**:
      增加更詳細的日誌輸出，用於追蹤影像讀取和編碼失敗的情況，以利於 `ERR_INCOMPLETE_CHUNKED_ENCODING` 的除錯。
   14 - **`main.py`**: 配置 `logging` 模組，使所有後端日誌包含時間戳，提高可追溯性。
   15
   16 此實作確保了後端能夠執行即時影像分析，同時前端也能顯示即時影像，從而提升了整體功能性和使用者體驗。