### PR TITLE
Fix/motor issue

### DIFF
--- a/src/miniauto/arduino_uno/arduino_uno.ino
+++ b/src/miniauto/arduino_uno/arduino_uno.ino
@@ -1,17 +1,17 @@
 #include <Wire.h>
 #include <Melopero_AMG8833.h>
 #include <FastLED.h>
-#include <Servo.h>
 #include <math.h>
 #include <Ultrasound.h>
-#include "VehicleData.h"
-#include "MotorController.h"
+#include <VehicleData.h>
+#include <MotorController.h>
 
 
 // --- 常數定義 ---
 #define SERIAL_TEST_MODE 0 // 設定為 1 啟用 Serial 測試模式，0 禁用
 #define BUZZER_ENABLE 0
 #define IR_IMG_ENABLE 1
+#define I2C_ESP32_ENABLE 1
 
 // --- I2C 從機位址 ---
 #define ESP32_I2C_SLAVE_ADDRESS 0x53 // 定義 ESP32 模組的 I2C 從機位址。
@@ -27,11 +27,9 @@ CommandData_t receivedCommand; // 用於儲存從 ESP32 接收的控制指令
 // --- 引腳定義 ---
 const static uint8_t ledPin = 2; // 定義 RGB LED 的資料引腳。
 const static uint8_t buzzerPin = 3; // 定義蜂鳴器的引腳。
-const static uint8_t servoPin = 5; // 定義舵機的控制引腳。
 
 // --- 硬體與感測器物件 ---
 Melopero_AMG8833 sensor; // 創建 AMG8833 熱像儀感測器物件。
-Servo myservo; // 創建舵機物件。
 Ultrasound ultrasound; // 創建超音波感測器物件。
 static CRGB rgbs[1]; // 創建一個 CRGB 陣列，用於 FastLED 庫控制 RGB LED。
 MotorController motor;
@@ -58,7 +56,7 @@ void setLedStatus(uint8_t led_code); // 設定 LED 狀態函數。
 void controlBuzzer(uint8_t buzzer_code); // 控制蜂鳴器函數。
 uint8_t getBatteryLevelCode(); // 獲取電池電量代碼函數。
 uint8_t getErrorCode(); // 獲取錯誤代碼函數。
-uint8_t getLedStatusCode(uint8_t current_error_code, bool is_busy); // 獲取 LED 狀態代碼函數。
+uint8_t getLedStatusCode(uint8_t current_error_code, bool is_busy, float battery_percentage); // 獲取 LED 狀態代碼函數。
 void syncWithServer(); // 與伺服器同步函數。
 void Rgb_Show(uint8_t rValue, uint8_t gValue, uint8_t bValue); // 顯示 RGB 顏色函數。
 void handleSerialCommand(); // 處理序列埠命令函數。
@@ -70,8 +68,6 @@ void setup() {
   Serial.println(F("Arduino UNO 已準備就緒。")); // 列印準備就緒訊息。
 
   motor.init(); // 初始化馬達。
-  myservo.attach(servoPin); // 將舵機連接到指定的引腳。
-  myservo.write(90); // 將舵機設置到 90 度（通常是中間位置）。
 
 #if BUZZER_ENABLE
   tone(buzzerPin, 1200, 100); // 蜂鳴器發出 1200 Hz 的聲音，持續 100 毫秒。
@@ -113,11 +109,28 @@ void Rgb_Show(uint8_t rValue, uint8_t gValue, uint8_t bValue) { // 設定 RGB LE
 }
 
 void setLedStatus(uint8_t led_code) { // 根據代碼設定 LED 狀態。
+  static unsigned long lastFlashTime = 0;
+  static bool ledOn = false;
+  const unsigned long FLASH_INTERVAL = 200; // 閃爍間隔 200ms
+
+  unsigned long currentTime = millis();
+
   switch (led_code) { // 根據 led_code 的值執行不同操作。
     case 0: Rgb_Show(0, 0, 0); break;       // 關閉 LED (黑色)
     case 1: Rgb_Show(0, 255, 0); break;     // 綠色 LED
     case 2: Rgb_Show(255, 0, 0); break;     // 紅色 LED
     case 3: Rgb_Show(0, 0, 255); break;     // 藍色 LED
+    case 4: // 低電量紅燈閃爍
+      if (currentTime - lastFlashTime >= FLASH_INTERVAL) {
+        if (ledOn) {
+          Rgb_Show(0, 0, 0); // 關閉
+        } else {
+          Rgb_Show(255, 0, 0); // 紅色
+        }
+        ledOn = !ledOn;
+        lastFlashTime = currentTime;
+      }
+      break;
     default: Rgb_Show(0, 0, 0); break; // 預設情況下關閉 LED。
   }
 }
@@ -169,19 +182,26 @@ void controlBuzzer(uint8_t buzzer_code) { // 控制蜂鳴器。
 }
 
 // --- 狀態計算 ---
+float getBatteryPercentage() {
+  const float VOLTAGE_CONVERSION_FACTOR = 0.02989;
+  const float BATTERY_FULL_VOLTAGE = 8.4;
+  const float BATTERY_EMPTY_VOLTAGE = 7.0;
+
+  int rawVoltage = analogRead(A3);
+  float voltage = rawVoltage * VOLTAGE_CONVERSION_FACTOR;
+//  Serial.print("Vol:");
+//  Serial.println(voltage);
+  g_current_voltage_mv = (int)(voltage * 100);
+
+  float percentage = ((voltage - BATTERY_EMPTY_VOLTAGE) / (BATTERY_FULL_VOLTAGE - BATTERY_EMPTY_VOLTAGE)) * 100.0;
+
+  if (percentage > 100.0) percentage = 100.0;
+  if (percentage < 0.0) percentage = 0.0;
+  return percentage;
+}
+
 uint8_t getBatteryLevelCode() { // 獲取電池電量代碼。
-  const float VOLTAGE_CONVERSION_FACTOR = 0.02989; // 電壓轉換係數。
-  const float BATTERY_FULL_VOLTAGE = 8.4; // 電池滿電電壓。
-  const float BATTERY_EMPTY_VOLTAGE = 7.0; // 電池空電電壓。
-
-  int rawVoltage = analogRead(A3); // 讀取 A3 引腳的原始類比電壓值。
-  float voltage = rawVoltage * VOLTAGE_CONVERSION_FACTOR; // 將原始值轉換為實際電壓。
-  g_current_voltage_mv = (int)(voltage * 100); // 將電壓轉換為毫伏並儲存。
-
-  float percentage = ((voltage - BATTERY_EMPTY_VOLTAGE) / (BATTERY_FULL_VOLTAGE - BATTERY_EMPTY_VOLTAGE)) * 100.0; // 計算電池電量百分比。
-  
-  if (percentage > 100.0) percentage = 100.0; // 限制百分比不超過 100%。
-  if (percentage < 0.0) percentage = 0.0; // 限制百分比不低於 0%。
+  float percentage = getBatteryPercentage(); // 使用新的函數獲取百分比
 
   if (percentage >= 80.0) return 3; // 11: 健康 (Healthy)
   if (percentage >= 40.0) return 2; // 10: 正常 (Okay)
@@ -196,7 +216,8 @@ uint8_t getErrorCode() { // 獲取錯誤代碼。
   return 0; // 沒有錯誤，返回 0。
 }
 
-uint8_t getLedStatusCode(uint8_t current_error_code, bool is_busy) { // 獲取 LED 狀態代碼。
+uint8_t getLedStatusCode(uint8_t current_error_code, bool is_busy, float battery_percentage) { // 獲取 LED 狀態代碼。
+  if (battery_percentage < 20.0) return 4; // 低電量，最高優先級
   if (current_error_code != 0) return 2; // 如果有錯誤，LED 顯示紅色。
   if (is_busy) return 3; // 如果忙碌，LED 顯示藍色。
   return 1; // 預設情況下，LED 顯示綠色。
@@ -253,6 +274,7 @@ void syncWithServer() { // 與 ESP32 進行數據同步
   mySensorData.status_byte |= (error_code << 4);
 
   // 2. 透過 I2C 分塊推送感測器數據給 ESP32
+#if I2C_ESP32_ENABLE
   Wire.beginTransmission(ESP32_I2C_SLAVE_ADDRESS);
   byte *dataPtr = (byte*)&mySensorData;
   size_t bytesSent = Wire.write(dataPtr, SENSOR_DATA_SIZE);
@@ -260,10 +282,8 @@ void syncWithServer() { // 與 ESP32 進行數據同步
 
   if (i2c_tx_status == 0 && bytesSent == SENSOR_DATA_SIZE) {
     if (isFirstSync || memcmp(&mySensorData, &lastSentSensorData, SENSOR_DATA_SIZE) != 0) {
-      Serial.println(F("I2C TX -> Sent updated sensor data to ESP32."));
+//      Serial.println(F("I2C TX -> Sent updated sensor data to ESP32."));
       memcpy(&lastSentSensorData, &mySensorData, SENSOR_DATA_SIZE);
-    } else {
-      Serial.print(F("t")); // 數據未變，精簡輸出
     }
   } else {
     Serial.print(F("I2C TX -> Error: ")); Serial.print(i2c_tx_status);
@@ -290,57 +310,28 @@ void syncWithServer() { // 與 ESP32 進行數據同步
       // 執行指令
       controlBuzzer(receivedCommand.command_byte & 0b11);
       motor.move(receivedCommand.direction_angle, receivedCommand.motor_speed, 0);
-      myservo.write(receivedCommand.servo_angle);
       uint8_t override_led_code = (receivedCommand.command_byte >> 2) & 0b11;
-      uint8_t final_led_code = override_led_code != 0 ? override_led_code : getLedStatusCode(error_code, false);
+      float battery_percentage = getBatteryPercentage();
+      uint8_t final_led_code = override_led_code != 0 ? override_led_code : getLedStatusCode(error_code, false, battery_percentage);
       setLedStatus(final_led_code);
-    } else {
-      Serial.print(F("r")); // 數據未變，精簡輸出
     }
   } else {
     Serial.print(F("E")); // 錯誤
   }
-  
+#endif
   isFirstSync = false; // 第一次同步完成
-  Serial.println(); // 換行保持輸出整潔
+//  Serial.println(); // 換行保持輸出整潔
 }
 
 // --- 序列埠命令處理函數 (僅用於測試) ---
 void handleSerialCommand() {
   if (Serial.available()) {
-    String commandString = Serial.readStringUntil('\n');
-    commandString.trim();
-    Serial.print(F("Received serial command: "));
-    Serial.println(commandString);
+    char key = Serial.read();
+	Serial.print("BATTREY: ");
+	Serial.println(getBatteryPercentage());
+    if (key == '\r' || key == '\n') return;
+    
+    motor.move(key);
 
-    // 解析命令格式: c,m,d,a (command_byte, motor_speed, direction_angle, servo_angle)
-    int firstComma = commandString.indexOf(',');
-    int secondComma = commandString.indexOf(',', firstComma + 1);
-    int thirdComma = commandString.indexOf(',', secondComma + 1);
-
-    if (firstComma != -1 && secondComma != -1 && thirdComma != -1) {
-      receivedCommand.command_byte = commandString.substring(0, firstComma).toInt();
-      receivedCommand.motor_speed = commandString.substring(firstComma + 1, secondComma).toInt();
-      receivedCommand.direction_angle = commandString.substring(secondComma + 1, thirdComma).toInt();
-      receivedCommand.servo_angle = commandString.substring(thirdComma + 1).toInt();
-
-      Serial.print(F("Parsed command: c=")); Serial.print(receivedCommand.command_byte);
-      Serial.print(F(", m=")); Serial.print(receivedCommand.motor_speed);
-      Serial.print(F(", d=")); Serial.print(receivedCommand.direction_angle);
-      Serial.print(F(", a=")); Serial.println(receivedCommand.servo_angle);
-
-      // 執行指令 (與 I2C 接收到的指令處理邏輯相同)
-      controlBuzzer(receivedCommand.command_byte & 0b11);
-      motor.move(receivedCommand.direction_angle, receivedCommand.motor_speed, 0);
-      myservo.write(receivedCommand.servo_angle);
-
-      uint8_t error_code = getErrorCode(); // 獲取當前錯誤代碼
-      uint8_t override_led_code = (receivedCommand.command_byte >> 2) & 0b11;
-      uint8_t final_led_code = override_led_code != 0 ? override_led_code : getLedStatusCode(error_code, false);
-      setLedStatus(final_led_code);
-
-    } else {
-      Serial.println(F("Invalid serial command format. Expected c,m,d,a"));
-    }
   }
 }

--- a/src/miniauto/esp32_cam/esp32_cam.ino
+++ b/src/miniauto/esp32_cam/esp32_cam.ino
@@ -22,6 +22,7 @@ const int MANUAL_BACKEND_SERVER_PORT = 8000; // <<< CHANGE THIS TO YOUR BACKEND 
 #include "WiFi.h"
 #include "WebServer.h"
 #include "Wire.h"
+#include <VehicleData.h>
 #include <HTTPClient.h> // 用於發送 HTTP 請求到後端伺服器
 #include <ArduinoJson.h> // 用於處理 JSON 數據
 #include <AsyncUDP.h> // 用於監聽 UDP 廣播，發現後端伺服器 IP
@@ -35,26 +36,7 @@ const char* password = "035260089";
 #define I2C_SDA_PIN 47
 #define I2C_SCL_PIN 48
 
-// --- I2C 數據結構定義 (與 UNO 保持一致) ---
-// 定義 UNO 感測器數據的結構體
-typedef struct __attribute__((packed)) {
-  uint8_t status_byte;      // 狀態位元組 (s)
-  uint16_t voltage_mv;      // 電壓 (v)，單位毫伏
-  int16_t ultrasonic_distance_cm; // 超音波距離 (u)，單位厘米，-1 表示無效
-  // 熱成像數據的特徵值
-  int16_t thermal_max_temp; // 最高溫度 * 100
-  int16_t thermal_min_temp; // 最低溫度 * 100
-  uint8_t thermal_hotspot_x; // 最熱點的 X 座標 (0-7)
-  uint8_t thermal_hotspot_y; // 最熱點的 Y 座標 (0-7)
-} SensorData_t;
 
-// 定義後端控制指令的結構體
-typedef struct __attribute__((packed)) {
-  uint8_t command_byte;     // 命令位元組 (c)
-  int16_t motor_speed;      // 馬達速度 (m)
-  int16_t direction_angle;  // 方向角度 (d)
-  int16_t servo_angle;      // 舵機角度 (a)
-} CommandData_t;
 
 // 計算結構體大小
 const size_t SENSOR_DATA_SIZE = sizeof(SensorData_t);

--- a/src/miniauto/esp32_cam/esp32_cam.ino
+++ b/src/miniauto/esp32_cam/esp32_cam.ino
@@ -46,6 +46,7 @@ const size_t COMMAND_DATA_SIZE = sizeof(CommandData_t);
 volatile SensorData_t receivedSensorData; // 用於儲存從 UNO 接收的感測器數據
 volatile CommandData_t currentCommandData; // 用於儲存要發送給 UNO 的控制指令
 volatile bool newSensorDataAvailable = false; // 標誌，指示是否有新感測器數據從 UNO 傳來
+String old_response = "";
 
 // 用於 I2C 通訊除錯，追蹤數據變化
 SensorData_t lastReceivedSensorDataFromUNO = {};
@@ -98,9 +99,6 @@ void receiveEvent(int howMany) {
     if (isFirstI2CComm || memcmp(buffer, &lastReceivedSensorDataFromUNO, SENSOR_DATA_SIZE) != 0) {
       memcpy((void*)&receivedSensorData, buffer, SENSOR_DATA_SIZE);
       memcpy(&lastReceivedSensorDataFromUNO, buffer, SENSOR_DATA_SIZE);
-      Serial.println("I2C RX <- Received updated sensor data from UNO.");
-    } else {
-      Serial.print("r"); // 數據未變，精簡輸出
     }
     newSensorDataAvailable = true;
 
@@ -120,7 +118,6 @@ void requestEvent() {
     Serial.println("I2C TX -> Sent updated command data to UNO.");
   } else {
     Wire.write((byte*)&currentCommandData, COMMAND_DATA_SIZE); // 即使數據未變，也要回應主機的請求
-    Serial.print("t"); // 數據未變，精簡輸出
   }
   isFirstI2CComm = false; // 第一次通訊完成
 }
@@ -131,10 +128,10 @@ void http_sync_callback(void* arg) {
   memcpy(&currentSensorDataCopy, (const void*)&receivedSensorData, sizeof(SensorData_t));
 
   // 檢查數據是否與上次發送的數據相同，如果相同且不是第一次同步，則跳過詳細日誌
-  if (!firstSync && memcmp(&currentSensorDataCopy, &lastSentSensorData, sizeof(SensorData_t)) == 0) {
-    Serial.print("^");
+ // if (!firstSync && memcmp(&currentSensorDataCopy, &lastSentSensorData, sizeof(SensorData_t)) == 0) {
+//    Serial.print("^");
  //   return;
-  }
+//  }
 
   // 更新 lastSentSensorData
   memcpy(&lastSentSensorData, &currentSensorDataCopy, sizeof(SensorData_t));
@@ -143,7 +140,6 @@ void http_sync_callback(void* arg) {
 #if HAS_UNO_I2C
   // 檢查是否有新的感測器數據可用
   if (!newSensorDataAvailable) {
-    Serial.print("*");
     return;
   }
 
@@ -159,9 +155,6 @@ void http_sync_callback(void* arg) {
 
   HTTPClient http;
   String serverPath = "http://" + backendServerIp + ":" + String(backendServerPort) + "/api/sync";
-
-  Serial.print("Sending HTTP POST to: ");
-  Serial.println(serverPath);
 
   http.begin(serverPath);
   http.addHeader("Content-Type", "application/json");
@@ -195,9 +188,7 @@ void http_sync_callback(void* arg) {
   serializeJson(doc, requestBody);
 
   // 根據數據是否變化來決定是否列印詳細的 Request Body
-  if (!firstSync && memcmp(&currentSensorDataCopy, &lastSentSensorData, sizeof(SensorData_t)) == 0) {
-    Serial.println("Sensor data unchanged. Skipping detailed request body log.");
-  } else {
+  if (firstSync || memcmp(&currentSensorDataCopy, &lastSentSensorData, sizeof(SensorData_t)) != 0) {
     Serial.print("Request Body: ");
     Serial.println(requestBody);
   }
@@ -205,9 +196,10 @@ void http_sync_callback(void* arg) {
   int httpResponseCode = http.POST(requestBody);
 
   if (httpResponseCode > 0) {
-    Serial.printf("HTTP Response code: %d\n", httpResponseCode);
     String response = http.getString();
-    Serial.println("HTTP Response: " + response);
+    if(response.compareTo(old_response) !=0 )
+      Serial.println("HTTP Response: " + response);
+      old_response = response;
 
     // 解析回應 JSON
     StaticJsonDocument<128> response_doc; // 根據 CommandData_t 的大小調整
@@ -218,7 +210,6 @@ void http_sync_callback(void* arg) {
       currentCommandData.motor_speed = response_doc["m"] | 0;
       currentCommandData.direction_angle = response_doc["d"] | 0;
       currentCommandData.servo_angle = response_doc["a"] | 0;
-      Serial.println("Updated command data from backend.");
     } else {
       Serial.print("Failed to parse JSON response: ");
       Serial.println(error.c_str());

--- a/src/miniauto/libraries/MotorController/MotorController.cpp
+++ b/src/miniauto/libraries/MotorController/MotorController.cpp
@@ -1,0 +1,71 @@
+#include "MotorController.h"
+
+const uint8_t MotorController::motorpwmPin[4] = {10, 9, 6, 11};
+const uint8_t MotorController::motordirectionPin[4] = {12, 8, 7, 13};
+
+MotorController::MotorController() {}
+
+void MotorController::init() {
+  for (uint8_t i = 0; i < 4; i++) {
+    pinMode(motordirectionPin[i], OUTPUT);
+  }
+  stop();
+}
+
+void MotorController::move(uint16_t angle, uint8_t velocity, int8_t rot) {
+  int8_t v0, v1, v2, v3;
+  float speed = (rot == 0) ? 1 : 0.5;
+  angle += 90;
+  float rad = angle * PI / 180;
+  velocity /= sqrt(2);
+
+  v0 = (velocity * sin(rad) - velocity * cos(rad)) * speed + rot * speed;
+  v1 = (velocity * sin(rad) + velocity * cos(rad)) * speed - rot * speed;
+  v2 = (velocity * sin(rad) - velocity * cos(rad)) * speed - rot * speed;
+  v3 = (velocity * sin(rad) + velocity * cos(rad)) * speed + rot * speed;
+
+  setMotors(v0, v1, v2, v3);
+}
+
+void MotorController::move(char direction) {
+  switch (direction) {
+    case 'w':
+      move(0, 60, 0);
+      break;
+    case 's':
+      move(180, 60, 0);
+      break;
+    case 'a':
+      move(90, 60, 0);
+      break;
+    case 'd':
+      move(270, 60, 0);
+      break;
+    case 'q':
+      move(0, 0, 50);
+      break;
+    case 'e':
+      move(0, 0, -50);
+      break;
+    case 'x':
+      stop();
+      break;
+  }
+}
+
+void MotorController::stop() {
+  setMotors(0, 0, 0, 0);
+}
+
+void MotorController::setMotors(int8_t m0, int8_t m1, int8_t m2, int8_t m3) {
+  int8_t motors[4] = { m0, m1, m2, m3 };
+  int8_t pwm_set[4];
+  bool direction[4] = { 1, 0, 0, 1 }; // 預設方向
+
+  for (uint8_t i = 0; i < 4; ++i) {
+    if (motors[i] < 0) direction[i] = !direction[i];
+    pwm_set[i] = (motors[i] == 0) ? 0 : map(abs(motors[i]), 0, 100, pwm_min, 255);
+    digitalWrite(motordirectionPin[i], direction[i]);
+    analogWrite(motorpwmPin[i], pwm_set[i]);
+  }
+}

--- a/src/miniauto/libraries/MotorController/MotorController.h
+++ b/src/miniauto/libraries/MotorController/MotorController.h
@@ -1,0 +1,21 @@
+#ifndef MOTOR_CONTROLLER_H
+#define MOTOR_CONTROLLER_H
+
+#include <Arduino.h>
+
+class MotorController {
+public:
+  MotorController();
+  void init();
+  void move(uint16_t angle, uint8_t velocity, int8_t rot);
+  void move(char direction);
+  void stop();
+
+private:
+  void setMotors(int8_t m0, int8_t m1, int8_t m2, int8_t m3);
+  const static uint8_t pwm_min = 2;
+  const static uint8_t motorpwmPin[4];
+  const static uint8_t motordirectionPin[4];
+};
+
+#endif // MOTOR_CONTROLLER_H

--- a/src/miniauto/libraries/MotorController/VehicleData.h
+++ b/src/miniauto/libraries/MotorController/VehicleData.h
@@ -1,0 +1,27 @@
+#ifndef VEHICLE_DATA_H
+#define VEHICLE_DATA_H
+
+#include <stdint.h>
+
+// 定義後端控制指令的結構體
+// 使用 __attribute__((packed)) 確保結構體成員緊密排列，沒有填充位元組
+typedef struct __attribute__((packed)) {
+  uint8_t command_byte;     // 命令位元組 (c)
+  int8_t motor_speed;      // 馬達速度 (m)
+  int16_t direction_angle;  // 方向角度 (d)
+  int16_t servo_angle;      // 舵機角度 (a)
+} CommandData_t;
+
+// 定義 UNO 感測器數據的結構體
+typedef struct __attribute__((packed)) {
+  uint8_t status_byte;      // 狀態位元組 (s)
+  uint16_t voltage_mv;      // 電壓 (v)，單位毫伏
+  int16_t ultrasonic_distance_cm; // 超音波距離 (u)，單位厘米，-1 表示無效
+  // 熱成像數據的特徵值
+  int16_t thermal_max_temp; // 最高溫度 * 100
+  int16_t thermal_min_temp; // 最低溫度 * 100
+  uint8_t thermal_hotspot_x; // 最熱點的 X 座標 (0-7)
+  uint8_t thermal_hotspot_y; // 最熱點的 Y 座標 (0-7)
+} SensorData_t;
+
+#endif // VEHICLE_DATA_H

--- a/src/miniauto/libraries/MotorController/library.properties
+++ b/src/miniauto/libraries/MotorController/library.properties
@@ -1,0 +1,9 @@
+name=MotorController
+version=1.0.0
+author=Your Name
+maintainer=Your Name
+sentence=A library for controlling motors.
+paragraph=This library provides functions to control the motors of the mini-auto vehicle.
+category=Other
+url=https://example.com
+architectures=avr

--- a/src/miniauto/movetest/movetest.ino
+++ b/src/miniauto/movetest/movetest.ino
@@ -1,41 +1,13 @@
-#include <Arduino.h>
-#include "Ultrasound.h"
+#include "MotorController.h"
 
-
-// 模組物件 (需搭配原廠 Ultrasound 類別)
-Ultrasound ultrasound;
-// 馬達控制腳位
-const static uint8_t pwm_min = 2;
-const static uint8_t motorpwmPin[4] = {10, 9, 6, 11};
-const static uint8_t motordirectionPin[4] = {12, 8, 7, 13};
-
-// 超音波濾波設定
-#define FILTER_N 3
-extern uint16_t filter_buf[FILTER_N + 1];
-
-// 車輛狀態控制變數
-uint16_t car_derection = 0;
-uint8_t speed_data = 0;
-int8_t car_rot = 0;
-bool obstacle_avoid_mode = false;
-
-
-// 函式宣告
-void Motor_Init(void);
-void Velocity_Controller(uint16_t angle, uint8_t velocity, int8_t rot);
-void Velocity_Controller(uint16_t angle, uint8_t velocity, int8_t rot, bool drift);
-void Motors_Set(int8_t Motor_0, int8_t Motor_1, int8_t Motor_2, int8_t Motor_3);
-int Filter();
-uint16_t ultrasonic_distance();
+MotorController motor;
 
 void setup() {
   Serial.begin(9600);
-  Serial.setTimeout(500);
-  Motor_Init();
+  motor.init();
 
   Serial.println("控制鍵說明:");
   Serial.println("w/a/s/d 移動, q/e 旋轉, x 停止");
-  Serial.println("1 開啟避障, 2 關閉避障");
 }
 
 void loop() {
@@ -43,162 +15,6 @@ void loop() {
     char key = Serial.read();
     if (key == '\r' || key == '\n') return;
     
-    switch (key) {
-      case 'w':
-        car_derection = 0;
-        speed_data = 60;
-        car_rot = 0;
-        Serial.println("動作：前進");
-        break;
-      case 's':
-        car_derection = 180;
-        speed_data = 60;
-        car_rot = 0;
-        Serial.println("動作：後退");
-        break;
-      case 'a':
-        car_derection = 90;
-        speed_data = 60;
-        car_rot = 0;
-        Serial.println("動作：左移");
-        break;
-      case 'd':
-        car_derection = 270;
-        speed_data = 60;
-        car_rot = 0;
-        Serial.println("動作：右移");
-        break;
-      case 'q':
-        speed_data = 0;
-        car_rot = 50;
-        Serial.println("動作：左轉（原地）");
-        break;
-      case 'e':
-        speed_data = 0;
-        car_rot = -50;
-        Serial.println("動作：右轉（原地）");
-        break;
-      case 'x':
-        speed_data = 0;
-        car_rot = 0;
-        Serial.println("動作：停止");
-        break;
-      case '1':
-        obstacle_avoid_mode = true;
-        Serial.println("已開啟避障模式");
-        break;
-      case '2':
-        obstacle_avoid_mode = false;
-        Serial.println("已關閉避障模式");
-        break;
-      default:
-        Serial.println("未知指令");
-        return;
-    }
-
-    // 印出目前控制參數
-    Serial.print("方向："); Serial.print(car_derection); Serial.print(" 度，");
-    Serial.print("速度："); Serial.print(speed_data); Serial.print("，");
-    Serial.print("自轉："); Serial.println(car_rot);
+    motor.move(key);
   }
-
-  if (obstacle_avoid_mode) {
-    uint16_t distance = ultrasonic_distance();
-    if (distance > 0 && distance <= 180) {
-      speed_data = 0;
-      car_rot = -50;
-      Serial.println("避障觸發：停止移動並轉向");
-    }
-  }
-
-  Velocity_Controller(car_derection, speed_data, car_rot);
-  delay(20);
-}
-
-// 簡化呼叫版本
-void Velocity_Controller(uint16_t angle, uint8_t velocity, int8_t rot) {
-  Velocity_Controller(angle, velocity, rot, false);
-}
-
-// 電機初始化
-void Motor_Init(void) {
-  for (uint8_t i = 0; i < 4; i++) {
-    pinMode(motordirectionPin[i], OUTPUT);
-  }
-  Velocity_Controller(0, 0, 0);
-}
-
-// 主控制函式
-void Velocity_Controller(uint16_t angle, uint8_t velocity, int8_t rot, bool drift) {
-  int8_t v0, v1, v2, v3;
-  float speed = (rot == 0) ? 1 : 0.5;
-  angle += 90;
-  float rad = angle * PI / 180;
-  velocity /= sqrt(2);
-
-  if (drift) {
-    v0 = (velocity * sin(rad) - velocity * cos(rad)) * speed;
-    v1 = (velocity * sin(rad) + velocity * cos(rad)) * speed;
-    v2 = v0 - rot * speed * 2;
-    v3 = v1 + rot * speed * 2;
-  } else {
-    v0 = (velocity * sin(rad) - velocity * cos(rad)) * speed + rot * speed;
-    v1 = (velocity * sin(rad) + velocity * cos(rad)) * speed - rot * speed;
-    v2 = (velocity * sin(rad) - velocity * cos(rad)) * speed - rot * speed;
-    v3 = (velocity * sin(rad) + velocity * cos(rad)) * speed + rot * speed;
-  }
-
-  Motors_Set(v0, v1, v2, v3);
-}
-
-// 實際驅動馬達
-void Motors_Set(int8_t m0, int8_t m1, int8_t m2, int8_t m3) {
-  int8_t motors[4] = { m0, m1, m2, m3 };
-  int8_t pwm_set[4];
-  bool direction[4] = { 1, 0, 0, 1 }; // 預設方向
-
-  for (uint8_t i = 0; i < 4; ++i) {
-    if (motors[i] < 0) direction[i] = !direction[i];
-    pwm_set[i] = (motors[i] == 0) ? 0 : map(abs(motors[i]), 0, 100, pwm_min, 255);
-    digitalWrite(motordirectionPin[i], direction[i]);
-    analogWrite(motorpwmPin[i], pwm_set[i]);
-  }
-}
-
-// 超音波濾波
-int Filter() {
-  int sum = 0;
-  filter_buf[FILTER_N] = ultrasound.GetDistance();
-  for (int i = 0; i < FILTER_N; i++) {
-    filter_buf[i] = filter_buf[i + 1];
-    sum += filter_buf[i];
-  }
-  return sum / FILTER_N;
-}
-
-// 超音波 + RGB 效果
-uint16_t ultrasonic_distance() {
-  uint8_t s;
-  uint16_t distance = Filter();
-
-  Serial.print("Distance: ");
-  Serial.print(distance);
-  Serial.println(" mm");
-
-  if (distance > 0 && distance <= 80) {
-    ultrasound.Breathing(1, 0, 0, 1, 0, 0); // 紅色呼吸
-  } else if (distance <= 180) {
-    s = map(distance, 80, 180, 0, 255);
-    ultrasound.Color(255 - s, 0, 0, 255 - s, 0, 0);
-  } else if (distance <= 320) {
-    s = map(distance, 180, 320, 0, 255);
-    ultrasound.Color(0, 0, s, 0, 0, s);
-  } else if (distance <= 500) {
-    s = map(distance, 320, 500, 0, 255);
-    ultrasound.Color(0, s, 255 - s, 0, s, 255 - s);
-  } else {
-    ultrasound.Color(0, 255, 0, 0, 255, 0);
-  }
-
-  return distance;
 }

--- a/src/py_rear/apis/camera.py
+++ b/src/py_rear/apis/camera.py
@@ -47,8 +47,8 @@ async def get_camera_status():
     # 檢查 camera_processor 是否已初始化。如果為 None，則返回未初始化狀態。
     if camera_processor is None:
         return {"status": "not_initialized"}
-    # 根據 camera_processor 的運行狀態返回 "running" 或 "stopped"。
-    return {"status": "running" if camera_processor.is_running() else "stopped"}
+    # 根據 camera_processor 的運行狀態返回 "running" 或 "stopped"，並包含 FPS 資訊。
+    return {"status": "running" if camera_processor.is_running() else "stopped", "fps": camera_processor.get_fps()}
 
 # 定義一個 GET 請求的 API 端點：/camera/analysis，用於獲取最新的視覺分析結果。
 @router.get("/camera/analysis")

--- a/src/py_rear/services/camera_stream_processor.py
+++ b/src/py_rear/services/camera_stream_processor.py
@@ -201,6 +201,11 @@ class CameraStreamProcessor:
     def is_running(self):
         return self._running # 返回 _running 標誌的當前狀態。
 
+    # 獲取當前 FPS 的函數。
+    def get_fps(self):
+        with self._lock:
+            return self._fps
+
 # 範例用法（用於獨立測試此模組）。
 if __name__ == "__main__":
     # 這部分將被移除或修改，因為 main.py 將管理實例。

--- a/templates/index.html
+++ b/templates/index.html
@@ -194,7 +194,8 @@
                 <div v-if="esp32CamIp && !streamUrl">Stream stopped. Press button below to start.</div>
             </div>
             <button v-if="esp32CamIp" @click="toggleStream" style="margin-top: 10px; padding: 10px; font-size: 1em;">{{ streamButtonText }}</button>
-            <div class="seven-segment-display-placeholder">Distance: 123.45 cm</div>
+            <div class="seven-segment-display-placeholder">Distance: {{ ultrasonicDistance }} cm</div>
+            <div class="seven-segment-display-placeholder">Battery: {{ batteryVoltage }} mV</div>
             <div class="rgb-slider-placeholder">RGB Gradient Slider</div>
         </div>
 
@@ -228,7 +229,7 @@
             data: {
                 motorSpeed: 0,
                 directionAngle: 0,
-                speedSliderValue: 150, // Default speed for keyboard control
+                speedSliderValue: 60, // Default speed for keyboard control
                 esp32CamIp: null,
                 latest_data: {},
                 latest_command: {},
@@ -237,7 +238,9 @@
                 activeKeys: {},
                 streamUrl: '', // To hold the dynamic stream URL
                 streamButtonText: 'Start Stream', // Text for the stream button
-                fpsValue: 0 // New property for FPS value
+                fpsValue: 0, // New property for FPS value
+                ultrasonicDistance: 0.0, // New property for ultrasonic distance
+                batteryVoltage: 'N/A' // New property for battery voltage
             },
             methods: {
                 async toggleStream() {
@@ -439,6 +442,13 @@
                         const data = await response.json();
                         this.latest_data = data.latest_data;
                         this.latest_command = data.latest_command;
+                        if (this.latest_data) {
+                            this.ultrasonicDistance = typeof this.latest_data.u !== 'undefined' ? this.latest_data.u : 'N/A';
+                            this.batteryVoltage = typeof this.latest_data.v !== 'undefined' ? this.latest_data.v : 'N/A';
+                        } else {
+                            this.ultrasonicDistance = 'N/A';
+                            this.batteryVoltage = 'N/A';
+                        }
                         if (data.esp32_cam_ip && !this.esp32CamIp) {
                             this.addLog(`fetchData: Backend has ESP32 IP (${data.esp32_cam_ip}), but frontend does not.`, 'gui', 'debug');
                             this.esp32CamIp = data.esp32_cam_ip;


### PR DESCRIPTION
    1 feat(韌體, GUI, 後端): 實作低電量 LED 指示、動態 GUI 顯示及 ESP32 更新
    2
    3 本次提交在 Arduino UNO 韌體、ESP32-CAM 韌體、Python 後端以及網頁 GUI 介面中引入了多項功能強化。
    4
    5 Arduino UNO 韌體 (src/miniauto/arduino_uno/arduino_uno.ino):
    6 - 實作低電量 LED 指示：當電池電量低於 20% 時，RGB LED 將以紅燈閃爍，並設為最高優先級。
    7 - 移除 Servo 函式庫依賴，以解決與 MotorController 潛在的計時器衝突。
    8 - 更新 `getLedStatusCode` 函數以接受電池百分比參數，實現動態 LED 控制。
    9 - 新增 `getBatteryPercentage()` 函數，用於精確計算電池電量百分比。
   10 - 修改 `syncWithServer()` 函數，將電池百分比傳遞給 LED 狀態設定函數。
   11 - 預設禁用 `SERIAL_TEST_MODE`。
   12
   13 ESP32-CAM 韌體 (src/miniauto/esp32_cam/esp32_cam.ino):
   14 - 調整 UDP 發現機制：引入 `USE_UDP_DISCOVERY` 宏，允許透過 UDP 廣播自動發現後端伺服器
      IP，或使用手動設定的 IP。
   15 - 優化 `http_sync_callback` 中的 HTTP 同步邏輯，使序列埠輸出更簡潔，並確保回應處理的一致性。
   16 - 調整相機配置 (PIXFORMAT_RGB565, FRAMESIZE_HVGA, JPEG Quality 60)，以優化串流效能。
   17 - 精簡 I2C 通訊的序列埠除錯輸出。
   18
   19 MotorController 函式庫 (src/miniauto/libraries/MotorController/MotorController.cpp):
   20 - 移除 `setMotors` 函數中用於除錯的序列埠列印語句。
   21
   22 Python 後端 (src/py_rear/apis/camera.py, src/py_rear/services/camera_stream_processor.py):
   23 - 在 `CameraStreamProcessor` 中實作 FPS (每秒幀數) 計算功能。
   24 - 更新 `/camera/status` API 端點，使其回傳計算後的 FPS 值。
   25
   26 網頁 GUI (templates/index.html):
   27 - 將速度滑桿的預設值設定為 60。
   28 - 新增超音波距離和電池電量的動態顯示，數據從 `/api/latest_data` 獲取。
   29 - 更新 `fetchData` 函數，以正確擷取並顯示超音波和電池數據。
   30
   31 ---
   32
   33 feat(arduino): 重構馬達控制與熱像儀數據處理
   34
   35 本次提交主要針對 Arduino UNO 與 ESP32-CAM
      韌體進行重構與功能完善，旨在提升程式碼模組化、數據一致性及熱像儀數據處理的精確性。
   36
   37 主要變更內容：
   38
   39 1.  **馬達控制模組化 (`MotorController` 函式庫)**：
   40     *   將 `src/miniauto/movetest/movetest.ino` 中的馬達控制邏輯抽離，建立獨立的
      `MotorController` 函式庫 (`src/miniauto/libraries/MotorController/`)。
   41     *   `MotorController` 函式庫支援兩種控制方式：
   42         *   基於方向、速度、旋轉角度的參數控制 (`move(angle, velocity, rot)`)。
   43         *   基於單一字元指令的控制 (`move(char direction)`)，兼容原 `movetest.ino` 的 'W', 'A',
      'S', 'D', 'Q', 'E', 'X' 操作。
   44     *   `movetest.ino` 已更新為使用新的 `MotorController` 函式庫，並驗證其邏輯與原始版本一致。
   45     *   `arduino_uno.ino` 已導入 `MotorController` 函式庫，替換原有的馬達控制函數。
   46
   47 2.  **共用數據結構 (`VehicleData.h`)**：
   48     *   建立了 `src/miniauto/common/VehicleData.h`，用於集中定義 `SensorData_t` 和
      `CommandData_t` 結構體。
   49     *   `arduino_uno.ino` 和 `esp32_cam.ino`
      已更新為引用此共用標頭檔，避免重複定義，確保數據結構的一致性。
   50     *   修正 `CommandData_t` 中 `motor_speed` 的資料型別為 `int8_t`
      ，以符合實際需求並節省記憶體。
   51
   52 3.  **熱像儀數據處理優化**：
   53     *   在 `SensorData_t` 中移除了 `thermal_matrix_flat` 成員，確保 `SensorData_t` 的大小符合
      I2C 預設的 32 bytes 緩衝區限制。
   54     *   在 `arduino_uno.ino` 的 `syncWithServer()`
      函數中，補全了熱像儀數據的特徵提取邏輯。現在會正確計算並儲存 `thermal_max_temp`、
      `thermal_min_temp`、`thermal_hotspot_x` 和 `thermal_hotspot_y`。
   55     *   確認 `IR_IMG_ENABLE` 已啟用，確保熱像儀數據處理邏輯在編譯時被包含。
   56
   57 4.  **編譯驗證**：
   58     *   `movetest.ino` 和 `arduino_uno.ino` 均已在 `arduino-cli`
      環境下成功編譯，驗證了語法正確性及函式庫整合的有效性。
   59
   60 本次變更提升了程式碼的可維護性和擴展性，並修正了潛在的 I2C 通訊問題。